### PR TITLE
Fix deploy: install gray-matter before content migration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,7 @@ jobs:
               -w /work \
               -e DATABASE_URL="$DATABASE_URL" \
               node:22-alpine sh -c '
+                npm install --no-save gray-matter reading-time 2>/dev/null
                 npx drizzle-kit push --force 2>&1 || echo "Schema migration warning"
                 npx tsx scripts/migrate-content.ts 2>&1
               '


### PR DESCRIPTION
## Summary
- The `migrate-content.ts` script runs inside a bare `node:22-alpine` container that doesn't have project dependencies
- Added `npm install --no-save gray-matter reading-time` before running the migration

## Context
All 3 deploy runs for PRs #17, #18, #19 failed with `Cannot find module 'gray-matter'`. This was a pre-existing issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)